### PR TITLE
Updates paths for `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # WordPress
-database
-fonts
-mu-plugins/
-themes/twenty*/
-uploads/
-db.php
+/database
+/fonts
+/mu-plugins
+/themes/twenty*
+/uploads
+/db.php
 
 # Dependencies
 node_modules/


### PR DESCRIPTION
This was blocking folders going into the theme. In particular, `fonts/`. I've changed the references to `/dirname` (e.g., `/fonts`) for the things we're ignoring in the `wp-content` folder.