### PR TITLE
Enable experimental Gutenberg blocks.

### DIFF
--- a/themes/bifrost-noise/src/Gutenberg/GutenbergExperiments.php
+++ b/themes/bifrost-noise/src/Gutenberg/GutenbergExperiments.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Experimental Gutenberg blocks.
+ *
+ * @author    Bifrost
+ * @copyright Copyright (c) 2026, WordPress
+ * @license   https://www.gnu.org/licenses/gpl-3.0.html GPL-3.0-or-later
+ * @link      https://github.com/wptrainingteam/developer-showcase
+ */
+
+declare(strict_types=1);
+
+namespace Bifrost\Noise\Gutenberg;
+
+use Bifrost\Noise\Contracts\Bootable;
+
+/**
+ * Handles filtering Gutenberg experiments.
+ */
+final class GutenbergExperiments implements Bootable
+{
+	/**
+	 * Which gutenberg experimental options to enable/disable.
+	 */
+	private const OPTIONS = [
+		'gutenberg-block-experiments' => 'true'
+	];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function boot(): void
+	{
+		add_filter('option_gutenberg-experiments', $this->experimentalOptions(...), 999999);
+	}
+
+	/**
+	 * Overwrites Gutenberg experimental options.
+	 */
+	private function experimentalOptions(mixed $experiments): array
+	{
+		if (! is_array($experiments)) {
+			$experiments = [];
+		}
+
+		return array_merge($experiments, self::OPTIONS);
+	}
+}

--- a/themes/bifrost-noise/src/Gutenberg/GutenbergServiceProvider.php
+++ b/themes/bifrost-noise/src/Gutenberg/GutenbergServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * DotCom service provider.
+ *
+ * @author    Bifrost
+ * @copyright Copyright (c) 2026, WordPress
+ * @license   https://www.gnu.org/licenses/gpl-3.0.html GPL-3.0-or-later
+ * @link      https://github.com/wptrainingteam/developer-showcase
+ */
+
+declare(strict_types=1);
+
+namespace Bifrost\Noise\Gutenberg;
+
+use Bifrost\Noise\Contracts\Bootable;
+use Bifrost\Noise\Core\ServiceProvider;
+
+final class GutenbergServiceProvider extends ServiceProvider implements Bootable
+{
+	/**
+	 * @inheritDoc
+	 */
+	public function boot(): void
+	{
+		$this->container->get(GutenbergExperiments::class)->boot();
+	}
+}

--- a/themes/bifrost-noise/src/Theme.php
+++ b/themes/bifrost-noise/src/Theme.php
@@ -36,6 +36,7 @@ final class Theme extends Application
 		Block\Stylesheet\StylesheetServiceProvider::class,
 		Editor\EditorServiceProvider::class,
 		Frontend\FrontendServiceProvider::class,
+		Gutenberg\GutenbergServiceProvider::class,
 		PostType\PostTypeServiceProvider::class
 	];
 }


### PR DESCRIPTION
This is needed since they are disabled on DotCom. We need access to both the Tabs and Playlist blocks.