### PR TITLE
Add root phpcs.xml.dist for project PHP standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+	"name": "wptrainingteam/developer-showcase",
+	"description": "PHP development tooling for the Developer Showcase project",
+	"license": "GPL-3.0-or-later",
+	"scripts": {
+		"lint:php": "./vendor/bin/phpcs -d error_reporting=E_ALL^E_DEPRECATED -s --colors ."
+	},
+	"require-dev": {
+		"wp-coding-standards/wpcs": "^3.0",
+		"phpcompatibility/phpcompatibility-wp": "*",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+	},
+	"minimum-stability": "stable",
+	"prefer-stable": true,
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	}
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<ruleset name="Developer Showcase">
+	<description>PSR-12 naming/structure with WordPress whitespace conventions.</description>
+
+	<!-- Scan paths -->
+	<file>./plugins</file>
+	<file>./themes</file>
+
+	<!-- Excluded directories -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/build/*</exclude-pattern>
+
+	<!-- Only check PHP files -->
+	<arg name="extensions" value="php"/>
+	<arg name="colors"/>
+	<arg value="s"/>
+
+	<!--
+	  Base: PSR-12
+	  Override indentation and control-structure spacing below.
+	-->
+	<rule ref="PSR12">
+		<!-- Exclude space-indentation — we use tabs -->
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
+		<!-- Exclude PSR-12 control structure spacing — replaced by WP rule below -->
+		<exclude name="PSR12.ControlStructures.ControlStructureSpacing"/>
+	</rule>
+
+	<!-- Enforce tab indentation -->
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+
+	<!--
+	  WordPress whitespace rules:
+	  Spaces inside parentheses for control structures: if ( $foo )
+	-->
+	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
+	<rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
+	<rule ref="WordPress.WhiteSpace.OperatorSpacing"/>
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing"/>
+
+	<!-- WordPress security and best-practice sniffs -->
+	<rule ref="WordPress.Security"/>
+	<rule ref="WordPress.DB.PreparedSQL"/>
+	<rule ref="WordPress.WP.EnqueuedResources"/>
+	<rule ref="WordPress.PHP.NoSilencedErrors"/>
+	<rule ref="WordPress.WP.DeprecatedFunctions"/>
+
+	<!-- Disable Yoda conditions (team agreement) -->
+	<rule ref="WordPress.PHP.YodaConditions">
+		<severity>0</severity>
+	</rule>
+
+	<!-- PHP Compatibility -->
+	<rule ref="PHPCompatibilityWP"/>
+	<config name="testVersion" value="8.1-"/>
+
+	<!-- Pattern folder exclusions -->
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>*/patterns/*</exclude-pattern>
+	</rule>
+	<rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+		<exclude-pattern>*/patterns/*</exclude-pattern>
+	</rule>
+</ruleset>


### PR DESCRIPTION
## Summary

Adds the project-wide `phpcs.xml.dist` configuration as agreed in Discussion #22 and tracked by #47.

- **PSR-12 base** for naming conventions and code structure
- **WordPress whitespace conventions**: tab indentation, spaces inside parentheses for control structures, cast spacing, operator spacing, and array declaration spacing
- **WordPress security sniffs**: `WordPress.Security`, `WordPress.DB.PreparedSQL`, `WordPress.WP.EnqueuedResources`, `WordPress.PHP.NoSilencedErrors`, `WordPress.WP.DeprecatedFunctions`
- **Yoda conditions disabled** per team agreement
- **PHP 8.1+ compatibility** via `PHPCompatibilityWP`
- **Pattern folder exclusions** for `GlobalVariablesOverride` and `ScopeIndent`

Closes #47

## Test plan

- [ ] Run `composer install` (ensure `squizlabs/php_codesniffer`, `wp-coding-standards/wpcs`, and `phpcompatibility/phpcompatibility-wp` are available)
- [ ] Run `vendor/bin/phpcs` from the repo root and verify it picks up `phpcs.xml.dist`
- [ ] Confirm tab indentation is enforced and space indentation is flagged
- [ ] Confirm WordPress whitespace rules apply (e.g., `if( $x )` flags missing space after `if`)
- [ ] Confirm PSR-12 naming rules apply (e.g., class names must be PascalCase)
- [ ] Confirm files in `*/patterns/*` are excluded from `GlobalVariablesOverride` and `ScopeIndent` sniffs
- [ ] Confirm `*/vendor/*`, `*/node_modules/*`, and `*/build/*` directories are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)